### PR TITLE
Adds textAlignment to ComponentTextStyle

### DIFF
--- a/src/styles/text-styles/component-text-style-base.ts
+++ b/src/styles/text-styles/component-text-style-base.ts
@@ -2,8 +2,15 @@ import { DropCapStyle } from "./drop-cap-style";
 import { TextStyle } from "./text-style";
 import { TextStyleBase } from "./text-style-base";
 
+type TextAlignment
+    = "left"
+    | "center"
+    | "right"
+    | "justified"
+    | "none";
+
 /**
- * Signature/interface for a `ComponentTextSTtyle` object.
+ * Signature/interface for a `ComponentTextStyle` object.
  * @extends {TextStyle}
  * @see https://developer.apple.com/documentation/apple_news/componenttextstyle
  */
@@ -16,4 +23,5 @@ export interface ComponentTextStyleBase extends TextStyleBase {
     linkStyle?: TextStyle;
     paragraphSpacingAfter?: number; // Integer
     paragraphSpacingBefore?: number; // Integer
+    textAlignment?: TextAlignment;
 }


### PR DESCRIPTION
Adds the missing field `textAlignment` to `ComponentTextStyle`
https://developer.apple.com/documentation/apple_news/componenttextstyle