### PR TITLE
Fixes & addition to ConditionalComponentTextStyle

### DIFF
--- a/src/primitives/condition.ts
+++ b/src/primitives/condition.ts
@@ -48,6 +48,14 @@ export type ConditionViewLocation
     | "issue";
 
 /**
+ * Expression of possible values for condition `preferredColorScheme` field
+ */
+export type ConditionPreferredColorScheme
+    = "any"
+    | "light"
+    | "dark";
+
+/**
  * Signature/interface for a `Condition` object
  * @see https://developer.apple.com/documentation/apple_news/condition
  */
@@ -63,6 +71,7 @@ export interface Condition {
     minViewportAspectRatio?: number; // Unsigned Float
     minViewportWidth?: number; // Integer
     platform?: ConditionPlatform;
+    preferredColorScheme?: ConditionPreferredColorScheme;
     subscriptionStatus?: ConditionSubscriptionStatus;
     verticalSizeClass?: ConditionSizeClass;
     viewLocation?: ConditionViewLocation;

--- a/src/styles/text-styles/conditional-component-text-style.ts
+++ b/src/styles/text-styles/conditional-component-text-style.ts
@@ -7,5 +7,5 @@ import { ComponentTextStyleBase } from "./component-text-style-base";
  * @see https://developer.apple.com/documentation/apple_news/conditionalcomponenttextstyle
  */
 export interface ConditionalComponentTextStyle extends ComponentTextStyleBase {
-    condition: Condition[];
+    conditions: Condition[];
 }


### PR DESCRIPTION
1. Fixes field name to `conditions` https://developer.apple.com/documentation/apple_news/conditionalcomponenttextstyle

2. Added new condition `preferredColorScheme` for iOS 13 https://developer.apple.com/documentation/apple_news/condition