### PR TITLE
Add caption field for all image components

### DIFF
--- a/src/components/images/image-component.ts
+++ b/src/components/images/image-component.ts
@@ -1,6 +1,7 @@
 import { URI } from "../../primitives";
 import { Component } from "../component";
 import { ComponentLink } from "../component-link";
+import { CaptionDescriptor } from "./caption-descriptor";
 
 /**
  * Possible values for image component `role` fields
@@ -20,6 +21,7 @@ export interface ImageComponent extends Component {
   role: ImageComponentRole;
   URL: URI;
   accessibilityCaption?: string;
+  caption?: CaptionDescriptor | string;
   additions?: ComponentLink[];
   explicitContent?: boolean;
 }


### PR DESCRIPTION
These all have a `caption` field, so added it to the `ImageComponent` base.
https://developer.apple.com/documentation/apple_news/image
https://developer.apple.com/documentation/apple_news/photo
https://developer.apple.com/documentation/apple_news/figure
https://developer.apple.com/documentation/apple_news/portrait
https://developer.apple.com/documentation/apple_news/logo
