### PR TITLE
Build on prepublishOnly & only publish lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,13 +3,16 @@
   "version": "0.1.16",
   "description": "Types for Apple News Format, including a small selection of string validation functions",
   "main": "lib",
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "build": "./node_modules/.bin/tsc",
     "test": "./node_modules/.bin/ts-mocha ./tests/**/*.test.ts",
     "lint": "./node_modules/.bin/tslint ./src/**/*.ts",
     "prepublish": "npm run lint && npm test",
-    "clean": "rm -rf lib",
-    "postinstall": "npm run build"
+    "prepublishOnly": "npm run build",
+    "clean": "rm -rf lib"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
- Builds src to lib before publishing instead of making every user build it on npm install https://docs.npmjs.com/misc/scripts
- Only publish lib files to reduce size since they are the only files used