### PR TITLE
Fix component type checking & add tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1294,9 +1294,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.3.tgz",
-      "integrity": "sha512-FFgHdPt4T/duxx6Ndf7hwgMZZjZpB+U0nMNGVCYPq0rEzWKjEDobm4J6yb3CS7naZ0yURFqdw9Gwc7UOh/P9oQ==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
       "dev": true
     },
     "validate-npm-package-license": {

--- a/package.json
+++ b/package.json
@@ -3,15 +3,13 @@
   "version": "0.2.2",
   "description": "Types for Apple News Format, including a small selection of string validation functions",
   "main": "lib",
-  "files": [
-    "lib"
-  ],
   "scripts": {
     "build": "./node_modules/.bin/tsc",
     "test": "./node_modules/.bin/ts-mocha ./tests/**/*.test.ts",
     "lint": "./node_modules/.bin/tslint ./src/**/*.ts",
     "prepublish": "npm run lint && npm test",
     "prepublishOnly": "npm run build",
+    "postinstall": "if [ ! -d node_modules/apple-news-format/lib ]; then npm run build; fi",
     "clean": "rm -rf lib"
   },
   "husky": {
@@ -45,6 +43,6 @@
     "mocha": "^6.1.4",
     "ts-mocha": "^6.0.0",
     "tslint": "^5.16.0",
-    "typescript": "^3.4.3"
+    "typescript": "^3.8.3"
   }
 }

--- a/src/apple-news.d.ts
+++ b/src/apple-news.d.ts
@@ -30,11 +30,11 @@ declare namespace AppleNews {
 
   // Components
   export type Addition = Components.Addition;
+  export type LinkAddition = Components.LinkAddition;
   export type Behavior = Components.Behavior;
   export type ComponentAnimation = Components.ComponentAnimation;
   export type ComponentLink = Components.ComponentLink;
   export type Component = Components.Component;
-  export type Link = Components.Link;
   export type Scene = Components.Scene;
   export type BannerAdvertisement = Components.Advertisements.BannerAdvertisement;
   export type MediumRectangleAdvertisement = Components.Advertisements.MediumRectangleAdvertisement;

--- a/src/components/any-component.ts
+++ b/src/components/any-component.ts
@@ -1,24 +1,42 @@
-import {
-  Advertisements,
-  ArticleStructure,
-  AudioAndVideo,
-  AugmentedReality,
-  GalleriesAndMosaics,
-  Images,
-  Location,
-  SocialMedia,
-  Tables,
-  Text,
-} from ".";
+import * as Components from ".";
 
-export type AnyComponent =
-  | typeof Advertisements
-  | typeof ArticleStructure
-  | typeof AudioAndVideo
-  | typeof AugmentedReality
-  | typeof GalleriesAndMosaics
-  | typeof Images
-  | typeof Location
-  | typeof SocialMedia
-  | typeof Tables
-  | typeof Text;
+export type AnyComponent = Components.Advertisements.BannerAdvertisement
+ | Components.Advertisements.MediumRectangleAdvertisement
+ | Components.ArticleStructure.ArticleLink
+ | Components.ArticleStructure.Aside
+ | Components.ArticleStructure.Chapter
+ | Components.ArticleStructure.Container
+ | Components.ArticleStructure.Divider
+ | Components.ArticleStructure.Header
+ | Components.ArticleStructure.Section
+ | Components.AudioAndVideo.Audio
+ | Components.AudioAndVideo.EmbedWebVideo
+ | Components.AudioAndVideo.Music
+ | Components.AudioAndVideo.Video
+ | Components.AugmentedReality.ARKit
+ | Components.GalleriesAndMosaics.Gallery
+ | Components.GalleriesAndMosaics.Mosaic
+ | Components.Images.ArticleThumbnail
+ | Components.Images.Figure
+ | Components.Images.Image
+ | Components.Images.Logo
+ | Components.Images.Photo
+ | Components.Images.Portrait
+ | Components.Location.Map
+ | Components.Location.Place
+ | Components.SocialMedia.SocialMediaComponent
+ | Components.Tables.DataTable
+ | Components.Tables.HTMLTable
+ | Components.Text.ArticleTitle
+ | Components.Text.Author
+ | Components.Text.Body
+ | Components.Text.Byline
+ | Components.Text.Caption
+ | Components.Text.ConditionalText
+ | Components.Text.Heading
+ | Components.Text.Illustrator
+ | Components.Text.Intro
+ | Components.Text.Photographer
+ | Components.Text.PullQuote
+ | Components.Text.Quote
+ | Components.Text.Title;

--- a/src/components/article-structure/article-link.ts
+++ b/src/components/article-structure/article-link.ts
@@ -1,10 +1,10 @@
-import { Container } from "./container";
+import { ContainerComponent } from "./container-component";
 
 /**
  * Signature/interface for an `ArticleLink` object
  * @see https://developer.apple.com/documentation/apple_news/articlelink
- * @extends {Container}
+ * @extends {ContainerComponent}
  */
-export interface ArticleLink extends Container {
+export interface ArticleLink extends ContainerComponent {
   role: "article_link";
 }

--- a/src/components/article-structure/aside.ts
+++ b/src/components/article-structure/aside.ts
@@ -1,10 +1,10 @@
-import { Container } from "./container";
+import { ContainerComponent } from "./container-component";
 
 /**
  * Signature/interface for an `Aside` object
  * @see https://developer.apple.com/documentation/apple_news/aside
- * @extends {Container}
+ * @extends {ContainerComponent}
  */
-export interface Aside extends Container {
+export interface Aside extends ContainerComponent {
   role: "aside";
 }

--- a/src/components/article-structure/chapter.ts
+++ b/src/components/article-structure/chapter.ts
@@ -1,12 +1,12 @@
 import { Scene } from "../scene";
-import { Container } from "./container";
+import { ContainerComponent } from "./container-component";
 
 /**
  * Signature/interface for a `Chapter` object
  * @see https://developer.apple.com/documentation/apple_news/chapter
- * @extends {Container}
+ * @extends {ContainerComponent}
  */
-export interface Chapter extends Container {
+export interface Chapter extends ContainerComponent {
   role: "chapter";
   scene?: Scene;
 }

--- a/src/components/article-structure/container-component.ts
+++ b/src/components/article-structure/container-component.ts
@@ -1,0 +1,17 @@
+import { AnyComponent } from "../any-component";
+import { Component } from "../component";
+import { ComponentLink } from "../component-link";
+import { CollectionDisplay } from "./collection-display";
+import { ConditionalContainer } from "./conditional-container";
+import { HorizontalStackDisplay } from "./horizontal-stack-display";
+
+/**
+ * Base for container-like components
+ * @extends {Component}
+ */
+export interface ContainerComponent extends Component {
+  additions?: ComponentLink[];
+  conditional?: ConditionalContainer | ConditionalContainer[];
+  contentDisplay?: CollectionDisplay | HorizontalStackDisplay;
+  components?: AnyComponent[];
+}

--- a/src/components/article-structure/container.ts
+++ b/src/components/article-structure/container.ts
@@ -1,40 +1,10 @@
-import { AnyComponent } from "../any-component";
-import { Component } from "../component";
-import { ComponentLink } from "../component-link";
-import { CollectionDisplay } from "./collection-display";
-import { ConditionalContainer } from "./conditional-container";
-import { HorizontalStackDisplay } from "./horizontal-stack-display";
-
-/**
- * Expression for a possible range of types belonging to a given
- * component's property
- */
-export type ComponentFieldValue
-  = string
-  | number
-  | boolean
-  | string[];
-
-/**
- * Possible values for a container component role
- */
-export type ContainerRoles
-  = "container"
-  | "article_link"
-  | "header"
-  | "chapter"
-  | "aside"
-  | "section";
+import { ContainerComponent } from "./container-component";
 
 /**
  * Signature/interface for a `Container` object
  * @see https://developer.apple.com/documentation/apple_news/container
  * @extends {Component}
  */
-export interface Container extends Component {
-  role: ContainerRoles;
-  additions?: ComponentLink[];
-  conditional?: ConditionalContainer | ConditionalContainer[];
-  contentDisplay?: CollectionDisplay | HorizontalStackDisplay;
-  components?: AnyComponent[];
+export interface Container extends ContainerComponent {
+  role: "container";
 }

--- a/src/components/article-structure/divider.ts
+++ b/src/components/article-structure/divider.ts
@@ -1,12 +1,12 @@
 import { StrokeStyle } from "../../primitives";
-import { Component } from "../component";
+import { ContainerComponent } from "./container-component";
 
 /**
  * Signature/interface for a `Divider` object
  * @see https://developer.apple.com/documentation/apple_news/divider
- * @extends {Component}
+ * @extends {ContainerComponent}
  */
-export interface Divider extends Component {
+export interface Divider extends ContainerComponent {
   role: "divider";
   stroke?: StrokeStyle;
 }

--- a/src/components/article-structure/header.ts
+++ b/src/components/article-structure/header.ts
@@ -1,10 +1,10 @@
-import { Container } from "./container";
+import { ContainerComponent } from "./container-component";
 
 /**
  * Signature/interface for a `Header` object
  * @see https://developer.apple.com/documentation/apple_news/header
- * @extends {Container}
+ * @extends {ContainerComponent}
  */
-export interface Header extends Container {
+export interface Header extends ContainerComponent {
   role: "header";
 }

--- a/src/components/article-structure/section.ts
+++ b/src/components/article-structure/section.ts
@@ -1,12 +1,12 @@
 import { Scene } from "../scene";
-import { Container } from "./container";
+import { ContainerComponent } from "./container-component";
 
 /**
  * Signature/interface for a `Section` object
  * @see https://developer.apple.com/documentation/apple_news/section-ka8
- * @extends {Container}
+ * @extends {ContainerComponent}
  */
-export interface Section extends Container {
+export interface Section extends ContainerComponent {
   role: "section";
   scene?: Scene;
 }

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -10,11 +10,11 @@ import * as Tables from "./tables";
 import * as Text from "./text";
 
 export { Addition } from "./addition";
+export { LinkAddition } from "./link-addition";
 export { Behavior } from "./behavior";
 export { ComponentAnimation } from "./component-animation";
 export { ComponentLink } from "./component-link";
 export { Component } from "./component";
-export { Link } from "./link";
 export { Scene } from "./scene";
 export {
   Advertisements,

--- a/src/components/link-addition.ts
+++ b/src/components/link-addition.ts
@@ -9,6 +9,6 @@ import { Addition } from "./addition";
  * @see https://developer.apple.com/documentation/apple_news/link
  * @extends {Addition}
  */
-export interface Link extends Addition {
+export interface LinkAddition extends Addition {
   URL: URI | IdentifierURI;
 }

--- a/src/components/social-media/index.ts
+++ b/src/components/social-media/index.ts
@@ -1,13 +1,19 @@
 import { URI } from "../../primitives";
 import { Component } from "../component";
 
+type SocialMediaRole
+  = "instagram"
+  | "facebook_post"
+  | "tweet";
+
 /**
  * Signature/interface for a `SocialMediaComponent` object
  * @see https://developer.apple.com/documentation/apple_news/instagram
- * @see https://developer.apple.com/documentation/apple_news/facebook
+ * @see https://developer.apple.com/documentation/apple_news/facebookpost
  * @see https://developer.apple.com/documentation/apple_news/tweet
  * @extends {Component}
  */
 export interface SocialMediaComponent extends Component {
+  role: SocialMediaRole;
   URL: URI;
 }

--- a/src/components/text/text-component.ts
+++ b/src/components/text/text-component.ts
@@ -2,7 +2,7 @@ import {
   ComponentTextStyle,
   InlineTextStyle,
 } from "../../styles/text-styles";
-import { Addition } from "../addition";
+import { LinkAddition } from "../link-addition";
 import { ComponentBase } from "../component-base";
 import { ConditionalText } from "./conditional-text";
 
@@ -32,7 +32,7 @@ export interface TextComponent extends ComponentBase {
   role: TextComponentRole;
   format?: TextComponentFormat;
   text: string;
-  additions?: Addition[];
+  additions?: LinkAddition[];
   conditional?: ConditionalText[];
   inlineTextStyles?: InlineTextStyle[];
   textStyle?: ComponentTextStyle | string;

--- a/src/components/text/title.ts
+++ b/src/components/text/title.ts
@@ -9,5 +9,4 @@ import {
  */
 export interface Title extends TextComponent {
   role: "title";
-
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,11 +30,11 @@ export namespace AppleNews {
 
   // Components
   export type Addition = Components.Addition;
+  export type LinkAddition = Components.LinkAddition;
   export type Behavior = Components.Behavior;
   export type ComponentAnimation = Components.ComponentAnimation;
   export type ComponentLink = Components.ComponentLink;
   export type Component = Components.Component;
-  export type Link = Components.Link;
   export type Scene = Components.Scene;
   export type BannerAdvertisement = Components.Advertisements.BannerAdvertisement;
   export type MediumRectangleAdvertisement = Components.Advertisements.MediumRectangleAdvertisement;

--- a/tests/document.test.ts
+++ b/tests/document.test.ts
@@ -1,0 +1,16 @@
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import { join } from "path";
+import { typecheck } from "./utils/typecheck";
+
+describe("Apple News Document type checking", () => {
+  it("Should pass with a valid document", () => {
+    const errors = typecheck(join(__dirname, "documents/valid.ts"));
+    expect(errors.length).to.equal(0);
+  }).timeout(5000);
+
+  it("Should fail with an invalid document", () => {
+    const errors = typecheck(join(__dirname, "documents/invalid.ts"));
+    expect(errors.length).to.equal(3);
+  }).timeout(5000);
+});

--- a/tests/documents/invalid.ts
+++ b/tests/documents/invalid.ts
@@ -1,0 +1,31 @@
+import AppleNews from "../../src/index";
+
+const document: AppleNews.ArticleDocument = {
+  version: "1.10.1",
+  identifier: "12345",
+  language: "en",
+  title: "Title",
+  layout: {
+    columns: 1,
+    width: 1000,
+  },
+  components: [
+    {
+      role: "foo",
+      text: "fail",
+    },
+    {
+      role: "title",
+      foo: "fail",
+    },
+    {
+      role: "title",
+      components: [
+        {
+          role: "title",
+          text: "A title in a container",
+        },
+      ],
+    },
+  ],
+};

--- a/tests/documents/valid.ts
+++ b/tests/documents/valid.ts
@@ -1,0 +1,27 @@
+import AppleNews from "../../src/index";
+
+const document: AppleNews.ArticleDocument = {
+  version: "1.10.1",
+  identifier: "12345",
+  language: "en",
+  title: "Title",
+  layout: {
+    columns: 1,
+    width: 1000,
+  },
+  components: [
+    {
+      role: "title",
+      text: "A title",
+    },
+    {
+      role: "container",
+      components: [
+        {
+          role: "title",
+          text: "A title in a container",
+        },
+      ],
+    },
+  ],
+};

--- a/tests/utils/typecheck.js
+++ b/tests/utils/typecheck.js
@@ -1,0 +1,38 @@
+const ts = require("typescript");
+
+const DefaultOptions = {
+  noEmit: true,
+  target: ts.ScriptTarget.ES2019,
+  module: ts.ModuleKind.CommonJS,
+};
+
+function typecheck(filepath, options = DefaultOptions) {
+  const program = ts.createProgram([filepath], options);
+  const emitResult = program.emit();
+  const diagnostics = ts
+    .getPreEmitDiagnostics(program)
+    .concat(emitResult.diagnostics);
+  return formatDiagnostics(diagnostics);
+}
+
+function formatDiagnostics(diagnostics) {
+  return diagnostics.map((diagnostic) => {
+    const { messageText: info, file } = diagnostic;
+    const result = {
+      message: info.messageText,
+      category: info.category,
+      code: info.code,
+    };
+    if (file) {
+      const { line, character } = file.getLineAndCharacterOfPosition(
+        diagnostic.start
+      );
+      result.file = file.fileName;
+      result.line = line + 1;
+      result.character = character + 1;
+    }
+    return result;
+  });
+}
+
+module.exports = { typecheck };


### PR DESCRIPTION
Retry of https://github.com/Robert-Fairley/apple-news-format/pull/11, which wasn't correct.

Currently, components are not properly type checked and allow any fields.  This fixes it to only allow the defined roles and proper fields associated with each role.

- Makes AnyComponent a proper union.
- Fixes container components to extend from a base class instead of the Container component.
- Fixes problems with LinkAddition, SocialMediaComponent uncovered by this.
- Adds tests that verify valid & invalid AppleNews Documents.