### PR TITLE
Remove build on postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,13 +3,15 @@
   "version": "0.2.3",
   "description": "Types for Apple News Format, including a small selection of string validation functions",
   "main": "lib",
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "build": "./node_modules/.bin/tsc",
     "test": "./node_modules/.bin/ts-mocha ./tests/**/*.test.ts",
     "lint": "./node_modules/.bin/tslint ./src/**/*.ts",
     "prepublish": "npm run lint && npm test",
     "prepublishOnly": "npm run build",
-    "postinstall": "if [ ! -d node_modules/apple-news-format/lib ]; then npm run build; fi",
     "clean": "rm -rf lib"
   },
   "husky": {


### PR DESCRIPTION
Removes the build step (tsc) on postinstall.  The library already gets properly built when published.

I had temporarily added it in this PR but forgot to remove it before it got merged:
https://github.com/Robert-Fairley/apple-news-format/commit/434b3402041a4fbd5453ce2e9f87cbdebef6d502
It was only there because we were referencing that long-lived PR as a dependency and there is no publish step when it doesn't come from npm.