### PR TITLE
Remove vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "deno.enable": false
-}


### PR DESCRIPTION
The settings file only contains a command to disable deno in the workspace. Likely an artifact that was committed by mistake.