### PR TITLE
Add Flexible Spacer, clean Conditional Container

### DIFF
--- a/src/components/any-component.ts
+++ b/src/components/any-component.ts
@@ -8,6 +8,7 @@ export type AnyComponent =
   | Components.ArticleStructure.Chapter
   | Components.ArticleStructure.Container
   | Components.ArticleStructure.Divider
+  | Components.ArticleStructure.FlexibleSpacer
   | Components.ArticleStructure.Header
   | Components.ArticleStructure.LinkButton
   | Components.ArticleStructure.Section

--- a/src/components/article-structure/conditional-container.ts
+++ b/src/components/article-structure/conditional-container.ts
@@ -4,6 +4,8 @@ import { Condition } from "../../primitives";
 import { ComponentStyle } from "../../styles/component-styles/component-style";
 import { Behavior } from "../behavior";
 import { ComponentAnimation } from "../component-animation";
+import { CollectionDisplay } from "./collection-display";
+import { HorizontalStackDisplay } from "./horizontal-stack-display";
 
 /**
  * Signature/interface for a `ConditionalContainer` object
@@ -14,6 +16,7 @@ export interface ConditionalContainer {
   anchor?: Anchor;
   animation?: ComponentAnimation;
   behavior?: Behavior;
+  contentDisplay?: CollectionDisplay | HorizontalStackDisplay;
   hidden?: false;
   layout?: ComponentLayout;
   style?: ComponentStyle;

--- a/src/components/article-structure/conditional-container.ts
+++ b/src/components/article-structure/conditional-container.ts
@@ -1,9 +1,4 @@
-import { Anchor } from "../../article-layout";
-import { ComponentLayout } from "../../article-layout/component-layout";
-import { Condition } from "../../primitives";
-import { ComponentStyle } from "../../styles/component-styles/component-style";
-import { Behavior } from "../behavior";
-import { ComponentAnimation } from "../component-animation";
+import { ConditionalComponent } from "../conditional-component";
 import { CollectionDisplay } from "./collection-display";
 import { HorizontalStackDisplay } from "./horizontal-stack-display";
 
@@ -11,13 +6,6 @@ import { HorizontalStackDisplay } from "./horizontal-stack-display";
  * Signature/interface for a `ConditionalContainer` object
  * @see https://developer.apple.com/documentation/apple_news/conditionalcontainer
  */
-export interface ConditionalContainer {
-  conditions: Condition | Condition[];
-  anchor?: Anchor;
-  animation?: ComponentAnimation;
-  behavior?: Behavior;
+export interface ConditionalContainer extends ConditionalComponent {
   contentDisplay?: CollectionDisplay | HorizontalStackDisplay;
-  hidden?: false;
-  layout?: ComponentLayout;
-  style?: ComponentStyle;
 }

--- a/src/components/article-structure/flexible-spacer.ts
+++ b/src/components/article-structure/flexible-spacer.ts
@@ -1,0 +1,11 @@
+import { Component } from "../component";
+
+/**
+ * Signature/interface for a `FlexibleSpacer` object
+ * @see https://developer.apple.com/documentation/apple_news/flexiblespacer
+ * @extends {Component}
+ */
+
+export interface FlexibleSpacer extends Component {
+  role: "spacer";
+}

--- a/src/components/article-structure/index.ts
+++ b/src/components/article-structure/index.ts
@@ -5,6 +5,7 @@ export { CollectionDisplay } from "./collection-display";
 export { ConditionalContainer } from "./conditional-container";
 export { Container } from "./container";
 export { Divider } from "./divider";
+export { FlexibleSpacer } from "./flexible-spacer";
 export { Header } from "./header";
 export { HorizontalStackDisplay } from "./horizontal-stack-display";
 export { LinkButton } from "./link-button";

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,10 @@ import { ArticleDocument as RootArticleDocument } from "./article-document";
 import { AutoPlacement as RootAutoPlacement } from "./auto-placement";
 import { AnyComponent as RootAnyComponent } from "./components/any-component";
 import { ConditionalAutoPlacement as RootConditionalAutoPlacement } from "./conditional-auto-placement";
-import { ConditionalDocumentStyle as RootConditionalDocumentStyle, DocumentStyle as RootDocumentStyle } from "./document-style";
+import {
+  ConditionalDocumentStyle as RootConditionalDocumentStyle,
+  DocumentStyle as RootDocumentStyle,
+} from "./document-style";
 
 export namespace AppleNews {
   // Root
@@ -25,7 +28,8 @@ export namespace AppleNews {
   export type Anchor = ArticleLayout.Anchor;
   export type AutoPlacementLayout = ArticleLayout.AutoPlacementLayout;
   export type ComponentLayout = ArticleLayout.ComponentLayout;
-  export type ConditionalComponentLayout = ArticleLayout.ConditionalComponentLayout;
+  export type ConditionalComponentLayout =
+    ArticleLayout.ConditionalComponentLayout;
   export type Layout = ArticleLayout.Layout;
 
   // Components
@@ -36,16 +40,21 @@ export namespace AppleNews {
   export type ComponentLink = Components.ComponentLink;
   export type Component = Components.Component;
   export type Scene = Components.Scene;
-  export type ReplicaAdvertisement = Components.Advertisements.ReplicaAdvertisement;
+  export type ReplicaAdvertisement =
+    Components.Advertisements.ReplicaAdvertisement;
   export type ArticleLink = Components.ArticleStructure.ArticleLink;
   export type Aside = Components.ArticleStructure.Aside;
   export type Chapter = Components.ArticleStructure.Chapter;
   export type CollectionDisplay = Components.ArticleStructure.CollectionDisplay;
-  export type ConditionalContainer = Components.ArticleStructure.ConditionalContainer;
+  export type ConditionalContainer =
+    Components.ArticleStructure.ConditionalContainer;
   export type Container = Components.ArticleStructure.Container;
   export type Divider = Components.ArticleStructure.Divider;
+  export type FlexibleSpacer = Components.ArticleStructure.FlexibleSpacer;
   export type Header = Components.ArticleStructure.Header;
-  export type HorizontalStackDisplay = Components.ArticleStructure.HorizontalStackDisplay;
+  export type HorizontalStackDisplay =
+    Components.ArticleStructure.HorizontalStackDisplay;
+  export type LinkButton = Components.ArticleStructure.LinkButton;
   export type Section = Components.ArticleStructure.Section;
   export type Audio = Components.AudioAndVideo.Audio;
   export type EmbedWebVideo = Components.AudioAndVideo.EmbedWebVideo;
@@ -122,10 +131,14 @@ export namespace AppleNews {
   export type Border = Styles.ComponentStyles.Border;
   export type ColorStrop = Styles.ComponentStyles.ColorStop;
   export type ComponentStyle = Styles.ComponentStyles.ComponentStyle;
-  export type ConditionalComponentStyle = Styles.ComponentStyles.ConditionalComponentStyle;
-  export type ConditionalTableCellStyle = Styles.ComponentStyles.ConditionalTableCellStyle;
-  export type ConditionalTableColumnStyle = Styles.ComponentStyles.ConditionalTableColumnStyle;
-  export type ConditionalTableRowStyle = Styles.ComponentStyles.ConditionalTableRowStyle;
+  export type ConditionalComponentStyle =
+    Styles.ComponentStyles.ConditionalComponentStyle;
+  export type ConditionalTableCellStyle =
+    Styles.ComponentStyles.ConditionalTableCellStyle;
+  export type ConditionalTableColumnStyle =
+    Styles.ComponentStyles.ConditionalTableColumnStyle;
+  export type ConditionalTableRowStyle =
+    Styles.ComponentStyles.ConditionalTableRowStyle;
   export type CornerMask = Styles.ComponentStyles.CornerMask;
   export type Fill = Styles.ComponentStyles.Fill;
   export type GradientFill = Styles.ComponentStyles.GradientFill;
@@ -141,7 +154,8 @@ export namespace AppleNews {
   export type TableStyle = Styles.ComponentStyles.TableRowStyle;
   export type VideoFill = Styles.ComponentStyles.VideoFill;
   export type ComponentTextStyle = Styles.TextStyles.ComponentTextStyle;
-  export type ConditionalComponentTextStyle = Styles.TextStyles.ConditionalComponentTextStyle;
+  export type ConditionalComponentTextStyle =
+    Styles.TextStyles.ConditionalComponentTextStyle;
   export type ConditionalTextStyle = Styles.TextStyles.ConditionalTextStyle;
   export type DropCapStyle = Styles.TextStyles.DropCapStyle;
   export type InlineTextStyle = Styles.TextStyles.InlineTextStyle;


### PR DESCRIPTION
Adds the [`FlexibleSpacer`](https://developer.apple.com/documentation/apple_news/flexiblespacer) component to the list. Also makes `LinkButton` (from #45) available as a global export.

While developing this, I also noticed that `ConditionalContainer` was missing its `contentDisplay` option and that it could be better extended from the [`ConditionalComponent`](https://developer.apple.com/documentation/apple_news/conditionalcomponent).

One side note, it seems my editor made some automated formatting changes when updating those global exports. If that’s something you’d like me to revert, I’m happy to do so.